### PR TITLE
Specify the default scene when exporting glTF bundles

### DIFF
--- a/Core/Helpers/GltfUtil.cs
+++ b/Core/Helpers/GltfUtil.cs
@@ -77,6 +77,7 @@ namespace FEZRepacker.Core.Helpers
                 translation.Z += StepOffsetZ;
             }
 
+            model.DefaultScene = scene;
             return model;
         }
 
@@ -95,6 +96,7 @@ namespace FEZRepacker.Core.Helpers
             node.Extras = entry.Extras ?? new JsonObject();
             node.Extras[PrimitiveTypeKey] = ConfiguredJsonSerializer.SerializeToNode(entry.Geometry.PrimitiveType);
 
+            model.DefaultScene = scene;
             return model;
         }
         


### PR DESCRIPTION
According to the glTF specification, a bundle can store multiple scenes. To determine which scene to load first, the bundle must specify the `scene` property.

However, if this property is not specified, then which scene to load next depends on the client. For example, Godot selects the first scene in the scene list when loading (and warns about this).

SharpGLTF does not specify a default scene when creating a single scene in code, so this commit implements an explicit definition of this.

See: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#scenes-overview