### PR TITLE
Add a CLI flag to skip `Updates.pak` when unpacking the game

### DIFF
--- a/Interface/Actions/UnpackGameAction.cs
+++ b/Interface/Actions/UnpackGameAction.cs
@@ -10,6 +10,7 @@ namespace FEZRepacker.Interface.Actions
         private const string DestinationFolder = "destination-folder";
         private const string UseLegacyAo = "use-legacy-ao";
         private const string UseLegacyTs = "use-legacy-ts";
+        private const string SkipUpdates = "skip-updates";
         
         public string Name => "--unpack-fez-content";
 
@@ -22,7 +23,8 @@ namespace FEZRepacker.Interface.Actions
             new CommandLineArgument(FezContentDirectory),
             new CommandLineArgument(DestinationFolder),
             new CommandLineArgument(UseLegacyAo, ArgumentType.Flag),
-            new CommandLineArgument(UseLegacyTs, ArgumentType.Flag)
+            new CommandLineArgument(UseLegacyTs, ArgumentType.Flag),
+            new CommandLineArgument(SkipUpdates, ArgumentType.Flag)
         };
 
         public void Execute(Dictionary<string, string> args)
@@ -37,6 +39,13 @@ namespace FEZRepacker.Interface.Actions
             {
                 if (!File.Exists(packagePath))
                 {
+                    if (packagePath.EndsWith("Updates.pak") && args.ContainsKey(SkipUpdates))
+                    {
+                        // Older, pre-FNA releases may not have this PAK.
+                        Console.WriteLine($"Skipping the {Path.GetFileName(packagePath)} directory.");
+                        continue;
+                    }
+                    
                     throw new Exception($"Given directory is not FEZ's Content directory (missing {Path.GetFileName(packagePath)}).");
                 }
             }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Unpacks entire .PAK package into specified directory (creates one if doesn't exi
 - `--unpack-decompressed [pak-path] [destination-folder] --use-legacy-ao --use-legacy-ts`
 Unpacks entire .PAK package into specified directory (creates one if doesn't exist).and attempts to decompress all XNB assets, but does not convert them.
 
-- `[--unpack-fez-content, -g] [fez-content-directory] [destination-folder] --use-legacy-ao --use-legacy-ts`
+- `[--unpack-fez-content, -g] [fez-content-directory] [destination-folder] --use-legacy-ao --use-legacy-ts --skip-updates`
 Unpacks and converts all game assets into specified directory (creates one if doesn't exist).
 
 - `[--pack, -p] [input-directory-path] [destination-pak-path] <include-pak-path>`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Unpacks entire .PAK package into specified directory (creates one if doesn't exi
 - `--unpack-decompressed [pak-path] [destination-folder] --use-legacy-ao --use-legacy-ts`
 Unpacks entire .PAK package into specified directory (creates one if doesn't exist).and attempts to decompress all XNB assets, but does not convert them.
 
-- `[--unpack-fez-content, -g] [fez-content-directory] [destination-folder] --use-legacy-ao --use-legacy-ts --skip-updates`
+- `[--unpack-fez-content, -g] [fez-content-directory] [destination-folder] --use-legacy-ao --use-legacy-ts`
 Unpacks and converts all game assets into specified directory (creates one if doesn't exist).
 
 - `[--pack, -p] [input-directory-path] [destination-pak-path] <include-pak-path>`


### PR DESCRIPTION
This makes possible to unpack resources from older versions of the game that may not have this file.